### PR TITLE
mysql logstach path doesnt match path in mysql-multi

### DIFF
--- a/attributes/logstash.rb
+++ b/attributes/logstash.rb
@@ -41,7 +41,7 @@ default['elkstack']['config']['custom_logstash']['name'].push('mysql')
 default['elkstack']['config']['custom_logstash']['mysql']['name'] = 'input_mysql'
 default['elkstack']['config']['custom_logstash']['mysql']['cookbook'] = 'stack_commons'
 default['elkstack']['config']['custom_logstash']['mysql']['source'] = 'logstash/input_mysql.conf.erb'
-default['elkstack']['config']['custom_logstash']['mysql']['variables'] = { path: '/var/log/mysql/**' }
+default['elkstack']['config']['custom_logstash']['mysql']['variables'] = { path: '/var/log/mysql**' }
 
 # Nginx
 default['elkstack']['config']['custom_logstash']['name'].push('nginx')


### PR DESCRIPTION
mysql logs are not captured in logstash as the path doesn't match the one set in mysqlmulti. 
https://github.com/rackspace-cookbooks/mysql-multi/blob/master/templates/default/my.cnf.erb#L7
