### PR TITLE
Changed rabbitmq monitoring port

### DIFF
--- a/recipes/newrelic.rb
+++ b/recipes/newrelic.rb
@@ -86,7 +86,7 @@ if node['newrelic']['license']
     meetme_config['rabbitmq'] = {
       name: node['hostname'],
       host: 'localhost',
-      port: node['rabbitmq']['port'],
+      port: 15_672,
       username: 'monitor',
       password: node['stack_commons']['rabbitmq']['monitor_password'],
       api_path: '/api'

--- a/test/unit/spec/newrelic_spec.rb
+++ b/test/unit/spec/newrelic_spec.rb
@@ -115,6 +115,7 @@ describe 'stack_commons::newrelic' do
           end
           it 'configures newrelic meetme for rabbitmq' do
             expect(chef_run).to render_file('/etc/newrelic/newrelic-plugin-agent.cfg').with_content('rabbitmq')
+            expect(chef_run).to render_file('/etc/newrelic/newrelic-plugin-agent.cfg').with_content('15672')
           end
         end
         context 'redis' do


### PR DESCRIPTION
The port used to monitor is the management one, not the rabbitmq one, it's always 15672 and I cannot see an attribute to define it, which is why I've hardcoded it.
