### PR TITLE
Revert removal of mysql::client from mysql_base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is used to list changes made in each version of the stack_commons cook
 0.0.28
 ------
 
-- Please put your changelog here. Don't bump to version 0.0.29 until after release.
+- @martinb3 - Revert removal of mysql::client RE: https://github.com/rackspace-cookbooks/pythonstack/issues/131 and #64.
 
 0.0.27
 ------

--- a/recipes/mysql_base.rb
+++ b/recipes/mysql_base.rb
@@ -46,6 +46,7 @@ end
 
 include_recipe 'build-essential'
 include_recipe 'mysql::server'
+include_recipe 'mysql::client'
 include_recipe 'mysql-multi'
 include_recipe 'database::mysql'
 


### PR DESCRIPTION
Revert removal of mysql::client RE: https://github.com/rackspace-cookbooks/pythonstack/issues/131 and #64.
