### PR TITLE
Fix newrelic/mysql monitoring

### DIFF
--- a/attributes/newrelic.rb
+++ b/attributes/newrelic.rb
@@ -1,0 +1,2 @@
+default['stack_commons']['newrelic']['mysql']['user'] = 'newrelic-agent'
+default['stack_commons']['newrelic']['mysql']['password'] = nil

--- a/test/unit/spec/newrelic_spec.rb
+++ b/test/unit/spec/newrelic_spec.rb
@@ -76,8 +76,11 @@ describe 'stack_commons::newrelic' do
           it 'includes newrelic_plugins::mysql recipe' do
             expect(chef_run).to include_recipe('newrelic_plugins::mysql')
           end
+          it 'creates the mysql user for newrelic' do
+            expect(chef_run).to create_mysql_database_user('newrelic-agent')
+          end
           it 'configures newrelic mysql plugin with monitoring user' do
-            expect(chef_run).to render_file('/opt/newrelic/newrelic_mysql_plugin/config/plugin.json').with_content('raxmon-agent')
+            expect(chef_run).to render_file('/opt/newrelic/newrelic_mysql_plugin/config/plugin.json').with_content('newrelic-agent')
           end
           # We should add all the specs on https://github.com/newrelic-platform
           # For now we just have a simple test


### PR DESCRIPTION
Newrelic monitoring was not working properly because we were using the raxmon-agent db user which was created for 'localhost'. However the newrelic plugin for mysql was translating localhost to 127.0.0.1 and was getting a permission denied as raxmon-agent@127.0.0.1 were not existing.

In order to not rely on the cloud_monitoring user for newrelic I'm creating a new db user, it should not impact anything related to cloudmonitoring, it allows to fix the '127.0.0.1' by using best_ip_for and it allows to enable newrelic even if we don't have cloud_monitoring.

I didn't fallback to 127.0.0.1 because we almost never configure mysql to bind to localhost.
