### PR TITLE
forcing newer apache2 cookbook for apache2.4 support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ description 'provides common supporting features for stacks'
 # don't bump this until *after* releasing to supermarket ('bump for dev')
 version '0.0.36'
 
-depends 'apache2'
+depends 'apache2', '>= 3.0.0'
 depends 'apt'
 depends 'build-essential'
 depends 'chef-sugar'


### PR DESCRIPTION
Signed-off-by: Matthew Thode mthode@mthode.org
