### PR TITLE
Add python setuptools workaround for centos

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -51,3 +51,10 @@ suites:
   - name: default
     run_list:
       - recipe[wrapper::default]
+
+# Can be used as a quick way to test the python bugs on centos 6
+# https://github.com/rackspace-cookbooks/stack_commons/issues/85
+#
+#  - name: python
+#    run_list:
+#      - recipe[stack_commons::python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ stack_commons CHANGELOG
 
 This file is used to list changes made in each version of the stack_commons cookbook.
 
+0.0.37
+------
+
+- @martinb3 - Move python recipe out by itself, add workaround for #85
+
 0.0.35
 ------
 

--- a/recipes/newrelic.rb
+++ b/recipes/newrelic.rb
@@ -28,6 +28,9 @@ if node['newrelic']['license']
   node.override['newrelic']['server_monitoring']['ssl'] = true
   node.default['newrelic_meetme_plugin']['license'] = node['newrelic']['license']
 
+  # required by newrelic base agent
+  include_recipe 'stack_commons::python'
+
   if node['stack_commons']['application_monitoring']['php']['enabled'] == true
     include_recipe 'php'  # needed so that we don't install apache by installing the agent
     node.override['newrelic']['php_agent']['agent_action'] = 'upgrade'
@@ -37,8 +40,6 @@ if node['newrelic']['license']
   end
   if node['stack_commons']['application_monitoring']['python']['enabled'] == true
     include_recipe 'newrelic::python_agent'
-    include_recipe 'python'
-    include_recipe 'python::pip'
   end
   if node['stack_commons']['application_monitoring']['java']['enabled'] == true
     include_recipe 'newrelic::java_agent'
@@ -151,13 +152,6 @@ if node['newrelic']['license']
 
   node.override['newrelic_meetme_plugin']['services'] = meetme_config
   node.default['newrelic_meetme_plugin']['package_name'] = 'newrelic-plugin-agent'
-
-  # Upgrade setuptools globally to ensure pip works
-  include_recipe 'python::pip'
-  python_pip 'setuptools' do
-    action :upgrade
-    version node['python']['setuptools_version']
-  end
 
   include_recipe 'newrelic_meetme_plugin'
 else

--- a/recipes/python.rb
+++ b/recipes/python.rb
@@ -1,0 +1,39 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: stack_commons
+# Recipe:: python
+#
+# Copyright 2014, Rackspace Hosting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Upgrade pip once and setuptools twice to ensure pip works -- (the three
+# include_recipes below map to python::default, with our install interjected
+# into the middle)
+
+include_recipe 'chef-sugar'
+
+include_recipe "python::#{node['python']['install_method']}"
+include_recipe 'python::pip'
+
+bash 'manually upgrade setuptools' do
+  user 'root'
+  cwd '/tmp'
+  code <<-EOH
+  easy_install --upgrade setuptools
+  EOH
+  only_if { rhel? }
+end
+
+include_recipe 'python::virtualenv'

--- a/test/unit/spec/newrelic_spec.rb
+++ b/test/unit/spec/newrelic_spec.rb
@@ -16,7 +16,7 @@ describe 'stack_commons::newrelic' do
             end.converge(described_recipe)
           end
 
-          %w( newrelic::python_agent python::package python::pip python newrelic_meetme_plugin).each do |recipe|
+          %w( newrelic::python_agent stack_commons::python newrelic_meetme_plugin).each do |recipe|
             it "includes #{recipe} recipe" do
               expect(chef_run).to include_recipe(recipe)
             end


### PR DESCRIPTION
Due to https://github.com/rackspace-cookbooks/stack_commons/issues/85, we have to manually run an install of setuptools because the one on centos 6 is so old, it doesn't work with pip or hardly anything else installed by chef, and it won't upgrade using pip itself.