### PR TITLE
correcting usage of securerandom.hex, also make sure dbname is correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This file is used to list changes made in each version of the stack_commons cook
 
 0.0.41
 ------
-Bump for release
+- @prometheanfire - make the user actually 16 characters long (8 bytes in the function)
+- @prometheanfire - make sure the database name conforms to standards
 
 0.0.40
 ------

--- a/recipes/mysql_base.rb
+++ b/recipes/mysql_base.rb
@@ -103,8 +103,8 @@ node[stackname][node[stackname]['webserver']]['sites'].each do |port, sites|
       next unless site_opts['db_autocreate']
     end
     # set up the default DB name, user and password
-    db_name = "#{site_name[0...58]}-#{port}"
-    node.set_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['databases'][db_name]['mysql_user'] = SecureRandom.hex(16) # ~FC047
+    db_name = "#{site_name[0...58]}-#{port}".gsub(/[^0-9A-Za-z\-\_]/, '')
+    node.set_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['databases'][db_name]['mysql_user'] = SecureRandom.hex(8) # ~FC047
     node.set_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['databases'][db_name]['mysql_password'] = secure_password # ~FC047
     node.set_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['databases'][db_name]['privileges'] = %w(select update insert)
     node.set_unless[stackname][node[stackname]['webserver']]['sites'][port][site_name]['databases'][db_name]['global_privileges'] = []
@@ -160,7 +160,7 @@ node[stackname]['mysql']['databases'].each do |database, database_opts|
     action 'create'
   end
 
-  node.set_unless[stackname]['mysql']['databases'][database]['mysql_user'] = ::SecureRandom.hex(16)
+  node.set_unless[stackname]['mysql']['databases'][database]['mysql_user'] = ::SecureRandom.hex(8)
   node.set_unless[stackname]['mysql']['databases'][database]['mysql_password'] = secure_password
   node.set_unless[stackname]['mysql']['databases'][database]['privileges'] = %w(select update insert)
   node.set_unless[stackname]['mysql']['databases'][database]['global_privileges'] = []


### PR DESCRIPTION
make the user actually 16 characters long (8 bytes in the function)
make sure the database name conforms to standards

Signed-off-by: Matthew Thode <mthode@mthode.org>